### PR TITLE
Create a patch for prod build service worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   ],
   "scripts": {
     "dev": "extension dev",
-    "start": "extension start",
-    "build": "extension build",
+    "start": "npm run build && extension preview",
+    "build": "extension build && node ./patches/patch-service-worker.js",
     "format": "npx @biomejs/biome format",
     "format:write": "npx @biomejs/biome format --write",
     "lint": "npx @biomejs/biome lint",

--- a/patches/patch-service-worker.js
+++ b/patches/patch-service-worker.js
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+const path = "./dist/chrome/background/service_worker.js";
+/**
+ * This is hopefully a temporal patch. Currently something causes a document usage to be generated in
+ * the production build service worker file. However no obvious cause could be found easily and since it is
+ * only one usage, this patch can fix it until a further cause is found.
+ */
+const patchBackgroundScript = () => {
+  console.log(`Applying a patch for ${path}`);
+  if (!fs.existsSync(path)) {
+    console.error("Background script not found at:", path);
+    process.exit(1);
+  }
+
+  let script = fs.readFileSync(path, "utf8");
+
+  // Replace the problematic line
+  script = script.replace(/document\.baseURI\s*\|\|\s*/g, "");
+
+  fs.writeFileSync(path, script, "utf8");
+
+  console.log(`✅ ${path} patched successfully.`);
+};
+patchBackgroundScript();


### PR DESCRIPTION
- Something is generating a document usage in the service worker (which is not allowed in service workers) in the production build. For now workaround it using a small patch